### PR TITLE
add missing "#ddev-generated"

### DIFF
--- a/config.vitest-ui.yaml
+++ b/config.vitest-ui.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 web_extra_exposed_ports:
   - name: vitest-ui
     container_port: 51204


### PR DESCRIPTION
This PR fixes the following error:

"NOT overwriting /home/user13/tmp/test-vitest/.ddev/config.vitest-ui.yaml. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can remove the file and use ddev add-on get again if you want it to be replaced: signature was not found in file /home/user13/tmp/test-vitest/.ddev/config.vitest-ui.yaml"