### PR TITLE
refactor: vitest UI server interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ For example, to see the currently installed version of Vitest:
 
 ### `ddev vitest-ui`
 
-`ddev vitest-ui` attempts to start the Vitest UI server and launches the website in your default browser.
-If the server is already running, you may see "Port 51204 is already in use" error, which can be safely ignored.
+Use the following command to start the Vitest UI server and launch the site in your default browser:
 
 ```shell
-ddev vitest-ui
+ddev vitest-ui -s
 ```
+
+If the server is already started, use `ddev vitest-ui` to launch the site
 
 ## Auto-start Vitest UI
 

--- a/commands/host/vitest-ui
+++ b/commands/host/vitest-ui
@@ -3,7 +3,7 @@
 ## #ddev-generated
 ## Description: Launch the Vitest-UI.
 ## Usage: vitest-ui
-## Example: "ddev vitest-ui", "ddev vitest-ui -s", "ddev vitest-ui --start
+## Example: "ddev vitest-ui", "ddev vitest-ui -s", "ddev vitest-ui --start"
 
 if ! command -v ./node_modules/.bin/vitest  >/dev/null; then
   echo "Vitest is not available. You may need to install it. Eg. 'npm install -D vitest'"

--- a/commands/host/vitest-ui
+++ b/commands/host/vitest-ui
@@ -21,8 +21,8 @@ startUIServer() {
 while [ $# -gt 0 ]; do
   case "$1" in
   -s | --start)
-    startUIServer
-    shift
+    launch & startUIServer
+    exit 0;
     ;;
   esac
   shift

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -16,6 +16,23 @@ health_checks() {
   ddev exec "curl -s https://localhost:443/"
 }
 
+vitest-ui_health_checks() {
+  set -eu -o pipefail
+
+  # Check if the server is up
+  for i in {1..10}; do
+    if curl -s "https://${PROJNAME}.ddev.site:51204/__vitest__/" | grep "<title>Vitest</title>"; then
+      echo "Site is accessible"
+      return 0
+    fi
+    echo "Waiting for server..."
+    sleep 1
+  done
+
+  echo "Server did not start within the expected time."
+  exit 1
+}
+
 teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
@@ -47,6 +64,42 @@ teardown() {
 
   # ASSERT it can run tests.
   ddev vitest run | grep "1 passed (1)"
+}
+
+@test "vitest hijacks UI server" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
+  ddev restart
+
+  # Add required node package.
+  ddev npm install -D vitest @vitest/ui
+
+  # Add tests.
+  cp ${DIR}/tests/testdata/ ${TESTDIR}/tests/ -r
+
+  # Start vitest server in the background
+  nohup ddev vitest --ui > vitest.log 2>&1 &
+  vitest-ui_health_checks
+}
+
+@test "vitest-ui can start UI server" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
+  ddev restart
+
+  # Add required node package.
+  ddev npm install -D vitest @vitest/ui
+
+  # Add tests.
+  cp ${DIR}/tests/testdata/ ${TESTDIR}/tests/ -r
+
+  # Start vitest server in the background
+  nohup ddev vitest-ui -s > vitest.log 2>&1 &
+  vitest-ui_health_checks
 }
 
 # bats test_tags=release


### PR DESCRIPTION
This PR is a refactor how the commands interact with the Vitest UI server

1. Fix issue with command launch website after stopping the server.  Now `ddev vitest-ui -s` opens the site, then starts the server.
1. Add tests confirming Vitest UI is available on the host. Fixes #1
1. Updates documentation.