### PR TITLE
docs: fix badge regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/tyler36/ddev-vitest/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-vitest/actions/workflows/tests.yml)
-[![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-vite)](https://github.com/tyler36/ddev-vite/commits)
-[![release](https://img.shields.io/github/v/release/tyler36/ddev-vite)](https://github.com/tyler36/ddev-vite/releases/latest)
+[![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-vitest)](https://github.com/tyler36/ddev-vitest/commits)
+[![release](https://img.shields.io/github/v/release/tyler36/ddev-vitest)](https://github.com/tyler36/ddev-vitest/releases/latest)
 
 # ddev-vitest <!-- omit in toc -->
 


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where the README badges (Last Commit and Release) were pointing to the incorrect repository, `tyler36/ddev-vite` instead of `tyler36/ddev-vitest`.  This caused the badges to display inaccurate information and link to the wrong repository.

## How This PR Solves The Issue

This pull request updates the `README.md` file to correct the repository name in the "Last Commit" and "Release" badge URLs.  The URLs now correctly point to the `tyler36/ddev-vitest` repository.

**Changes Made:**

*   Updated the "Last Commit" badge URL in `README.md` from `https://github.com/tyler36/ddev-vite/commits` to `https://github.com/tyler36/ddev-vitest/commits`.
*   Updated the "Release" badge URL in `README.md` from `https://github.com/tyler36/ddev-vite/releases/latest` to `https://github.com/tyler36/ddev-vitest/releases/latest`.

## Manual Testing Instructions

N/A

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
